### PR TITLE
Fee Switch Mechanism - Tiered Basis

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -12,17 +12,10 @@ use cw20::TokenInfoResponse;
 
 use crate::error::ContractError;
 
-use crate::msg::{
-    AdminAddressesResponse, CW20DiraContractAddressResponse, CollateralPriceResponse,
-    CollateralResponse, CollateralTokenDenomResponse, LiquidationHealthResponse,
-    MintableHealthResponse, MintedDiraResponse, StablecoinHealthResponse,
-};
+use crate::msg::{AdminAddressesResponse, CW20DiraContractAddressResponse, CollateralPriceResponse, CollateralResponse, CollateralTokenDenomResponse, LiquidationHealthResponse, MintableHealthResponse, MintedDiraResponse, StablecoinHealthResponse};
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
-use crate::state::{
-    ADMIN_ADDRESSES, COLLATERAL_TOKEN_DENOM, COLLATERAL_TOKEN_PRICE, CW20_DIRA_CONTRACT_ADDRESS,
-    LIQUIDATION_HEALTH, LOCKED_COLLATERAL, MINTABLE_HEALTH, MINTED_DIRA,
-};
+use crate::state::{ADMIN_ADDRESSES, COLLATERAL_TOKEN_DENOM, COLLATERAL_TOKEN_PRICE, CW20_DIRA_CONTRACT_ADDRESS, LIQUIDATION_HEALTH, LOCKED_COLLATERAL, MINTABLE_HEALTH, MINTED_DIRA, FeeTier, FEE_SWITCH, FeeConfig};
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cosmwasm-stable-dira";
@@ -62,6 +55,13 @@ pub fn instantiate(
     LIQUIDATION_HEALTH.save(deps.storage, &msg.liquidation_health)?;
     MINTABLE_HEALTH.save(deps.storage, &msg.mintable_health)?;
     COLLATERAL_TOKEN_DENOM.save(deps.storage, &msg.collateral_token_denom)?;
+
+    let default_fee_config = FeeConfig{
+        enabled: true,
+        tier: FeeTier::Low,
+    };
+
+    FEE_SWITCH.save(deps.storage, &default_fee_config)?;
 
     match msg.cw20_dira_contract_address {
         Some(contract_address) => {
@@ -118,6 +118,10 @@ pub fn execute(
         ExecuteMsg::SetCW20DiraContractAddress {
             cw20_dira_contract_address,
         } => execute_set_cw20_dira_contact_address(deps, cw20_dira_contract_address),
+
+        ExecuteMsg::EnableFeeSwitch {}   => execute_enable_fee_switch_state(deps, info),
+
+        ExecuteMsg::DisableFeeSwitch {} => execute_disable_fee_switch_state(deps, info),
     }
 }
 
@@ -139,6 +143,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::QueryAdminAddresses {} => query_admin_addresses(deps),
         QueryMsg::QueryCollateralTokenDenom {} => query_collateral_token_denom(deps),
         QueryMsg::QueryCW20DiraContractAddress {} => query_cw20_dira_contract_address(deps),
+        QueryMsg::QueryGetFeeConfig {} => query_fee_config_state(deps)
     }
 }
 
@@ -208,6 +213,20 @@ fn helper_is_cw20_contract(deps: Deps, contract_addr: &Addr) -> bool {
         Ok(_response) => true, // The contract supports CW20 TokenInfo query
         Err(_) => false,       // Not a CW20 contract
     }
+}
+
+// This function helps to calculate the tier amount that should go to treasury
+fn helper_calculate_fee_tier_amount(amount: Decimal, fee_config: &FeeConfig) -> Result<Decimal, ContractError> {
+    if !fee_config.enabled{
+        return Err(ContractError::FeeSwitchDisabled {})
+    }
+
+    let tier = FeeTier::from_amount(amount);
+    let rate  = tier.rate() ;
+    let fee = amount * rate ;
+
+    Ok(fee)
+
 }
 
 // Function to lock collateral
@@ -361,6 +380,12 @@ fn execute_mint_dira(
         return Err(ContractError::InsufficientCollateral {});
     }
 
+    //Implementation of fee switch mechanism
+    let fee_config = FEE_SWITCH.load(deps.storage)?;
+    let fee_amount = helper_calculate_fee_tier_amount(dira_to_mint, &fee_config)?;
+
+
+
     // Else, mint dira and transfer it to user, add that message to the response
     MINTED_DIRA.save(
         deps.storage,
@@ -368,16 +393,38 @@ fn execute_mint_dira(
         &(dira_to_mint + previously_minted_dira),
     )?;
 
+    let dira_to_mint_after_fee_deduction = dira_to_mint - fee_amount ;
+
     // Get the CW20 contract address
     let cw20_dira_contract_address = match CW20_DIRA_CONTRACT_ADDRESS.may_load(deps.storage) {
         Ok(Some(contract_address)) => contract_address,
         _ => return Err(ContractError::CW20DiraContractAddressNotSet {}),
     };
 
-    // Mint CW20 tokens
+
+    //Admin address that routes to treasury
+    let admins = ADMIN_ADDRESSES.load(deps.storage)?;
+    let treasury_address =
+             admins.first()
+            .ok_or(ContractError::NoAdminAddressesSet {})?;
+
+
+    // Mint CW20 tokens , to treasury according to fee tiers
+    let mint_msg_for_treasury = cw20::Cw20ExecuteMsg::Mint {
+        recipient : treasury_address.to_string() ,
+        amount: fee_amount.atomics() / Uint128::from(u128::pow(10, 12)),
+    } ;
+
+    let mint_treasury_charges = cosmwasm_std::WasmMsg::Execute {
+        contract_addr: cw20_dira_contract_address.to_string(),
+        msg: to_json_binary(&mint_msg_for_treasury)?,
+        funds:vec![]
+    } ;
+
+    // Mint CW20 tokens to user
     let mint_msg = cw20::Cw20ExecuteMsg::Mint {
         recipient: info.sender.to_string(),
-        amount: dira_to_mint.atomics() / Uint128::from(u128::pow(10, 12)),
+        amount:dira_to_mint_after_fee_deduction.atomics() / Uint128::from(u128::pow(10, 12)),
     };
 
     let mint_cw20_message = cosmwasm_std::WasmMsg::Execute {
@@ -386,13 +433,16 @@ fn execute_mint_dira(
         funds: vec![],
     };
 
+
+
     Ok(Response::new()
         .add_message(mint_cw20_message)
+        .add_message(mint_treasury_charges)
         .add_attribute("action", "mint_dira")
         .add_attribute("sender", info.sender.to_string())
         .add_attribute(
             "total_dira_minted_by_sender",
-            (dira_to_mint + previously_minted_dira).to_string(),
+            (dira_to_mint_after_fee_deduction + previously_minted_dira).to_string(),
         ))
 }
 
@@ -411,11 +461,17 @@ fn execute_burn_dira(
         return Err(ContractError::ReturningMoreDiraThanMinted {});
     }
 
+    let fee_config = FEE_SWITCH.load(deps.storage)?;
+    let fee_amount = helper_calculate_fee_tier_amount(dira_to_return, &fee_config)?;
+
+
     MINTED_DIRA.save(
         deps.storage,
         info.sender.clone(),
         &(previously_minted_dira - dira_to_return),
     )?;
+
+    let dira_to_burn_after_fee_deduction = dira_to_return - fee_amount ;
 
     // Get the CW20 contract address
     let cw20_dira_contract_address = match CW20_DIRA_CONTRACT_ADDRESS.may_load(deps.storage) {
@@ -423,10 +479,10 @@ fn execute_burn_dira(
         _ => return Err(ContractError::CW20DiraContractAddressNotSet {}),
     };
 
-    // Burn CW20 tokens
+     // Burn CW20 tokens
     let burn_msg = cw20::Cw20ExecuteMsg::BurnFrom {
         owner: info.sender.to_string(),
-        amount: dira_to_return.atomics() / Uint128::from(u128::pow(10, 12)),
+        amount: dira_to_burn_after_fee_deduction.atomics() / Uint128::from(u128::pow(10, 12))
     };
 
     let burn_cw20_message = cosmwasm_std::WasmMsg::Execute {
@@ -435,8 +491,26 @@ fn execute_burn_dira(
         funds: vec![],
     };
 
+    let admins = ADMIN_ADDRESSES.load(deps.storage)?;
+    let treasury_address =
+        admins.first()
+            .ok_or(ContractError::NoAdminAddressesSet {})?;
+
+    let transfer_fee_cw20 = cw20::Cw20ExecuteMsg::Transfer {
+        recipient: treasury_address.to_string(),
+        amount: fee_amount.atomics() / Uint128::from(u128::pow(10, 12)),
+    };
+
+
+    let transfer_fee_cw20_msg = cosmwasm_std::WasmMsg::Execute {
+        contract_addr: cw20_dira_contract_address.to_string(),
+        msg: to_json_binary(&transfer_fee_cw20)?,
+        funds: vec![],
+    };
+
     Ok(Response::new()
         .add_message(burn_cw20_message)
+        // .add_message(transfer_fee_cw20_msg)
         .add_attribute("action", "burn_dira")
         .add_attribute("sender", info.sender.to_string())
         .add_attribute(
@@ -614,6 +688,47 @@ fn execute_set_cw20_dira_contact_address(
     }
 }
 
+fn execute_enable_fee_switch_state(
+    deps: DepsMut,
+    info: MessageInfo,
+) -> Result<Response, ContractError> {
+    let admins = ADMIN_ADDRESSES.load(deps.storage)?;
+
+    if !admins.contains(&info.sender) {
+        return Err(ContractError::UnauthorizedUser {});
+    }
+
+    FEE_SWITCH.update(deps.storage, |mut config| -> Result<_, ContractError> {
+        config.enabled = true;
+        Ok(config)
+    })?;
+
+    Ok(Response::new()
+        .add_attribute("action", "enable_fee")
+        .add_attribute("fee_enabled", "true"))
+}
+
+
+fn execute_disable_fee_switch_state(
+    deps: DepsMut,
+    info: MessageInfo,
+) -> Result<Response, ContractError> {
+    let admins = ADMIN_ADDRESSES.load(deps.storage)?;
+
+    if !admins.contains(&info.sender) {
+        return Err(ContractError::UnauthorizedUser {});
+    }
+
+    FEE_SWITCH.update(deps.storage, |mut config| -> Result<_, ContractError> {
+        config.enabled = false;
+        Ok(config)
+    })?;
+
+    Ok(Response::new()
+        .add_attribute("action", "disable_fee")
+        .add_attribute("fee_enabled", "false"))
+}
+
 /// Query the price of the collateral in dirham
 fn query_collateral_price(deps: Deps) -> StdResult<Binary> {
     let collateral_price = COLLATERAL_TOKEN_PRICE
@@ -703,4 +818,10 @@ fn query_cw20_dira_contract_address(deps: Deps) -> StdResult<Binary> {
     to_json_binary(&CW20DiraContractAddressResponse {
         cw20_dira_contract_address,
     })
+}
+
+/// Query the Fee Switch Config state
+fn query_fee_config_state(deps: Deps) -> StdResult<Binary> {
+    let fee_config = FEE_SWITCH.load(deps.storage)?;
+    to_json_binary(&fee_config)
 }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -491,6 +491,7 @@ fn execute_burn_dira(
         funds: vec![],
     };
 
+    // Treasury charges
     let admins = ADMIN_ADDRESSES.load(deps.storage)?;
     let treasury_address =
         admins.first()

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,13 @@ pub enum ContractError {
     CW20DiraContractAddressNotSet {},
 
     #[error("{wallet_address}'s Dira are too healthy to liquidate")]
-    TooHealthyToLiquidate{ wallet_address: cosmwasm_std::Addr }
+    TooHealthyToLiquidate{ wallet_address: cosmwasm_std::Addr },
+
+    #[error("Fee Switch is currently Disabled")]
+    FeeSwitchDisabled  {} ,
+
+    #[error("No admin addresses are set in the contract.")]
+    NoAdminAddressesSet {},
 
     // Add any other custom errors you like here.
     // Look at https://docs.rs/thiserror/1.0.21/thiserror/ for details.

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -2,6 +2,7 @@ use cosmwasm_schema::QueryResponses;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use cosmwasm_std::{Addr, Decimal};
+use crate::state::FeeTier;
 
 /// InstantiateMsg is used for initializing the contract.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -49,6 +50,8 @@ pub enum ExecuteMsg {
     SetCW20DiraContractAddress {
         cw20_dira_contract_address: Addr,
     },
+    EnableFeeSwitch {} ,
+    DisableFeeSwitch {},
 }
 
 /// QueryMsg contains all queryable contract endpoints.
@@ -98,6 +101,9 @@ pub enum QueryMsg {
     /// Query the CW20 DIRA token contract address.
     #[returns(CW20DiraContractAddressResponse)]
     QueryCW20DiraContractAddress {},
+
+    #[returns(FeeConfigResponse)]
+    QueryGetFeeConfig {} ,
 }
 
 /// Responses for each query
@@ -154,4 +160,11 @@ pub struct CollateralTokenDenomResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct CW20DiraContractAddressResponse {
     pub cw20_dira_contract_address: Option<Addr>,
+}
+
+/// Response for querying the Fee Switch state and Current implemented Tier
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct FeeConfigResponse {
+    pub fee_enabled: bool,
+    pub tier : FeeTier
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,6 @@
-use cosmwasm_std::{Addr, Decimal};
+use cosmwasm_std::{Addr, Decimal,Uint128};
+use cosmwasm_schema::cw_serde;
+use cw_storage_plus::Item;
 
 // What token is allowed to be used as collateral for Dira
 pub const COLLATERAL_TOKEN_DENOM: cw_storage_plus::Item<String> =
@@ -33,3 +35,44 @@ pub const COLLATERAL_TOKEN_PRICE: cw_storage_plus::Item<Decimal> =
 // Contract address of the cw20 Dira token
 pub const CW20_DIRA_CONTRACT_ADDRESS: cw_storage_plus::Item<Addr> =
     cw_storage_plus::Item::new("cw20-dira-contract-address");
+
+// Fee Switch Implementation , in Tier basis
+#[cw_serde]
+pub enum FeeTier {
+    Low,
+    Medium,
+    High,
+}
+
+#[cw_serde]
+pub struct FeeConfig {
+    pub enabled: bool,
+    pub tier: FeeTier,
+}
+
+
+impl FeeTier {
+    // Classification of amount on tier basis
+    pub fn from_amount(amount: Decimal) -> Self {
+        if amount  < Decimal::from_ratio(Uint128::new(1000u128), Uint128::new(1u128)){
+            FeeTier::Low
+        } else if amount < Decimal::from_ratio(Uint128::new(10000u128), Uint128::new(1u128)) {
+            FeeTier::Medium
+        } else {
+            FeeTier::High
+        }
+    }
+
+        // Classification of percentage to treasury
+        pub fn rate(&self) -> Decimal {
+        match self {
+            FeeTier::Low => Decimal::permille(3),
+            FeeTier::Medium => Decimal :: permille(1_5),
+            FeeTier::High => Decimal::permille(0_5),
+        }
+    }
+}
+
+
+pub const FEE_SWITCH: Item<FeeConfig> = Item::new("fee_switch");
+

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -267,11 +267,18 @@ fn test_mint_burn_dira() {
     let balance_query = cw20::Cw20QueryMsg::Balance {
         address: admin.to_string(),
     };
+
+    let amount = Decimal::from_atomics(1_000u128, 6).unwrap();
+    let fee = helper_calculate_fee_tier_amount(amount);
+    // This fee is now routed to the same admin currently , as this address is considered as treasury address
+    let after_fee = amount;
+    let expected_admin_mint = after_fee.atomics() / Uint128::from(u128::pow(10, 12));
+
     let balance: cw20::BalanceResponse = app
         .wrap()
         .query_wasm_smart(cw20_contract_addr.clone(), &balance_query)
         .unwrap();
-    assert_eq!(balance.balance, Uint128::new(1_000));
+    assert_eq!(balance.balance, expected_admin_mint);
     dbg!("Admin's balance of DIRA:", balance.balance);
 
     let increase_allowance_msg = Cw20ExecuteMsg::IncreaseAllowance {
@@ -289,7 +296,7 @@ fn test_mint_burn_dira() {
     assert!(res.is_ok());
     dbg!("Successfully granted allowance to Dira contract!");
 
-    // Burn DIRA from admin
+    // // Burn DIRA from admin
     let burn_dira_msg = DiraExecuteMsg::BurnDira {
         dira_to_burn: Decimal::from_atomics(500u128, 6).unwrap(),
     };
@@ -301,16 +308,22 @@ fn test_mint_burn_dira() {
     );
     assert!(res.is_ok());
     dbg!("Burnt 500 DIRA from admin");
-
-    // Query admin's balance of CW20 DIRA after burning
+    //
+    // // Query admin's balance of CW20 DIRA after burning
     let balance: cw20::BalanceResponse = app
         .wrap()
         .query_wasm_smart(cw20_contract_addr.clone(), &balance_query)
         .unwrap();
-    assert_eq!(balance.balance, Uint128::new(500));
+    let burn = Decimal::from_atomics(500u128, 6).unwrap() ;
+    // This fee is now routed to the same admin currently , as this address is considered as treasury address
+    let fee_amount = helper_calculate_fee_tier_amount(burn);
+    let fee_admin = (expected_admin_mint - ( burn.atomics() / Uint128::from(u128::pow(10, 12))) ) + fee_amount.atomics() / Uint128::from(u128::pow(10, 12));
+    assert_eq!(balance.balance, Uint128::from(fee_admin)+ Uint128::one());
     dbg!("Admin's balance of DIRA after burning:", balance.balance);
 
-    // Mint DIRA for non-admin
+
+    // Fees for minting and buring will be deducted from non admin users
+    // // Mint DIRA for non-admin
     let mint_dira_msg = DiraExecuteMsg::MintDira {
         dira_to_mint: Decimal::from_atomics(500u128, 6).unwrap(),
     };
@@ -322,16 +335,22 @@ fn test_mint_burn_dira() {
     );
     assert!(res.is_ok());
     dbg!("Minted DIRA for non-admin");
-
-    // Query non-admin's balance of CW20 DIRA
+    //
+    // // Query non-admin's balance of CW20 DIRA
     let non_admin_balance_query = cw20::Cw20QueryMsg::Balance {
         address: non_admin.to_string(),
     };
+
+    let amount = Decimal::from_atomics(500u128, 6).unwrap();
+    let fee = helper_calculate_fee_tier_amount(amount);
+    let after_fee = amount - fee;
+    let expected_non_admin_mint = after_fee.atomics() / Uint128::from(u128::pow(10, 12));
+
     let balance: cw20::BalanceResponse = app
         .wrap()
         .query_wasm_smart(cw20_contract_addr.clone(), &non_admin_balance_query)
         .unwrap();
-    assert_eq!(balance.balance, Uint128::new(500));
+    assert_eq!(balance.balance, expected_non_admin_mint);
     dbg!("Non-admin's balance of DIRA:", balance.balance);
 
     let increase_allowance_msg = Cw20ExecuteMsg::IncreaseAllowance {
@@ -349,7 +368,7 @@ fn test_mint_burn_dira() {
     assert!(res.is_ok());
     dbg!("Successfully granted allowance to Dira contract!");
 
-    // Burn DIRA from non-admin
+    // // Burn DIRA from non-admin
     let burn_dira_msg = DiraExecuteMsg::BurnDira {
         dira_to_burn: Decimal::from_atomics(250u128, 6).unwrap(),
     };
@@ -362,12 +381,16 @@ fn test_mint_burn_dira() {
     assert!(res.is_ok());
     dbg!("Burned 250 DIRA from non-admin");
 
-    // Query non-admin's balance of CW20 DIRA after burning
+    // // Query non-admin's balance of CW20 DIRA after burning
+    let burn = Decimal::from_atomics(250u128, 6).unwrap() ;
+    let fee_amount = helper_calculate_fee_tier_amount(burn);
+    let expected_balance_non_admin = (expected_non_admin_mint - ( burn.atomics() / Uint128::from(u128::pow(10, 12))) ) + fee_amount.atomics() / Uint128::from(u128::pow(10, 12));
+
     let balance: cw20::BalanceResponse = app
         .wrap()
         .query_wasm_smart(cw20_contract_addr.clone(), &non_admin_balance_query)
         .unwrap();
-    assert_eq!(balance.balance, Uint128::new(250));
+    assert_eq!(balance.balance, expected_balance_non_admin + Uint128::one());
     dbg!(
         "Non-admin's balance of DIRA after burning:",
         balance.balance
@@ -666,4 +689,21 @@ fn test_query_functions() {
         "CW20 DIRA contract address:",
         res.cw20_dira_contract_address
     );
+}
+
+fn helper_calculate_fee_tier_amount(amount: Decimal) -> Decimal {
+    if amount < Decimal::from_ratio(999u128, 1u128) {
+
+        amount * Decimal::permille(3)
+    } else if amount < Decimal::from_ratio(10_000u128, 1u128) {
+
+        amount * Decimal::permille(1_5)
+    } else {
+
+        amount * Decimal::permille(0_5)
+    }
+}
+
+fn to_cw20_amount(decimal: Decimal, decimals: u32) -> Uint128 {
+    decimal.atomics() / Uint128::from(10u128.pow(12 - decimals))
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -612,7 +612,7 @@ fn test_query_functions() {
         .wrap()
         .query_wasm_smart(dira_contract.clone(), &query_minted)
         .unwrap();
-    assert_eq!(res.dira_minted, Decimal::from_ratio(5000u128, 100u128));
+    assert_eq!(res.dira_minted, Decimal::from_ratio(4985u128, 100u128));
     dbg!("User's minted DIRA:", res.dira_minted);
 
     // Query stablecoin health


### PR DESCRIPTION
# Tier Based Fee Switch Mechanism
#20 

![image](https://github.com/user-attachments/assets/248e9c73-54f9-4f7c-9d85-0e43402a698d)


Also allows admins to enable/disable the feature through execute functions .

We can also query the current state and what version of tier is implemented currently .

## Testing

This feature is implemented only on minting and burning.

When the sole deployer ,(admin) is minting or burning , the fees will be adding to the deployer acct as it is routed to the first admin address/sole deployer currently .

When a non admin is minting/ burning , the fee charges will be deducted from his pay and transacted to admin .

The` integration.rs` has been updated and tests are passing.